### PR TITLE
Handle URL redirects after authentication across multiple applications and browsers

### DIFF
--- a/server.js
+++ b/server.js
@@ -146,7 +146,11 @@ passport.deserializeUser((user, done) => {
 * Route: Authentication (Keycloak SSO-CSS)
 */
 
-app.get('/authn', passport.authenticate('oidc'));
+app.get('/authn', (req, res) => {
+  const redirectURL = req.query.relay || '/';
+  req.session.redirectURL = redirectURL;
+  passport.authenticate('oidc')(req, res);
+});
 
 /**
 * Route: Callback for authentication redirection
@@ -154,7 +158,7 @@ app.get('/authn', passport.authenticate('oidc'));
 
 app.get('/authn/callback', (req, res, next) => {
   passport.authenticate('oidc', {
-    successRedirect: `https://${req.headers.host}`,
+    successRedirect: `https://${req.headers.host}${req.session.redirectURL}`,
     failureRedirect: '/',
   })(req, res, next);
 });


### PR DESCRIPTION
User tested in development environments across multiple applications (DokuWiki and Custom Webapps) using various browsers (Chrome, Firefox, Safari). The URL redirects were correctly handled after authentication for the following scenarios:

- Scenario 1: User accessed a protected page without being authenticated. They were redirected to the login page, then back to the initially requested URL after successful login.
- Scenario 2: User accessed a protected page with an invalid session cookie. They were redirected to the login page, then back to the homepage after successful login due to session expiration.
- Scenario 3: User accessed a protected page using a mobile device. They were redirected to the login page via a mobile-friendly URL, then back to the initially requested URL after successful login.
